### PR TITLE
Async reading + support for batteries that report voltage/current but not power

### DIFF
--- a/wattshow@izzo.ovh/extension.js
+++ b/wattshow@izzo.ovh/extension.js
@@ -8,7 +8,9 @@ const PanelMenu = imports.ui.panelMenu;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 
-const FILE_PATH = "/sys/class/power_supply/BAT0/power_now";
+const POWER_PATH = "/sys/class/power_supply/BAT0/power_now";
+const CURRENT_PATH = "/sys/class/power_supply/BAT0/current_now";
+const VOLTAGE_PATH = "/sys/class/power_supply/BAT0/voltage_now";
 
 let wattmeter = null;
 
@@ -42,8 +44,14 @@ function loadFile(path, cancellable = null) {
 }
 
 async function getPower(cancellable = null) {
-    const power = parseInt(await loadFile(FILE_PATH, cancellable));
-    return power / 1000000;
+    if (GLib.file_test(POWER_PATH, GLib.FileTest.EXISTS)) {
+        const power = parseInt(await loadFile(POWER_PATH, cancellable));
+        return power / 1000000;
+    } else {
+        const voltage = parseInt(await loadFile(VOLTAGE_PATH, cancellable));
+        const current = parseInt(await loadFile(CURRENT_PATH, cancellable));
+        return voltage * current / 1000000000000;
+    }
 }
 
 // WattMeter object

--- a/wattshow@izzo.ovh/extension.js
+++ b/wattshow@izzo.ovh/extension.js
@@ -1,6 +1,8 @@
+const ByteArray = imports.byteArray
 const Clutter = imports.gi.Clutter
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject
+const Gio = imports.gi.Gio;
 const Main = imports.ui.main;
 const PanelMenu = imports.ui.panelMenu;
 const Shell = imports.gi.Shell;
@@ -25,6 +27,25 @@ function disable()
     wattmeter = null;
 }
 
+function loadFile(path, cancellable = null) {
+    const file = Gio.File.new_for_path(path);
+    return new Promise((resolve, reject) => {
+        file.load_contents_async(cancellable, (source_object, res) => {
+            try {
+                const [,contents,] = source_object.load_contents_finish(res);
+                resolve(ByteArray.toString(contents));
+            } catch (e) {
+                reject(e);
+            }
+        });
+    });
+}
+
+async function getPower(cancellable = null) {
+    const power = parseInt(await loadFile(FILE_PATH, cancellable));
+    return power / 1000000;
+}
+
 // WattMeter object
 var WattMeter = GObject.registerClass(
     class WattMeter extends PanelMenu.Button {
@@ -33,26 +54,22 @@ var WattMeter = GObject.registerClass(
 
             this.buttonText = new St.Label({text:_("(...)"), y_align: Clutter.ActorAlign.CENTER});
             this.add_actor(this.buttonText);
+            this.cancellable = new Gio.Cancellable();
             this.interval = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 5000, this._refresh.bind(this));
             this._refresh();
         }
 
         destroy() {
             GLib.source_remove(this.interval)
+            this.cancellable.cancel();
 
             super.destroy();
         }
 
         _refresh() {
-            let power = 0;
-
-            if (GLib.file_test(FILE_PATH, GLib.FileTest.EXISTS)) {
-                power = Shell.get_file_contents_utf8_sync(FILE_PATH);
-            } else {
-                log('Error reading file ' + FILE_PATH);
-            }
-
-            this.buttonText.set_text((power / 1000000).toFixed(2).toString() + 'w');
+            getPower(this.cancellable).then(power => {
+                this.buttonText.set_text(power.toFixed(2).toString() + 'w');
+            }).catch(e => log(e.toString()));
 
             return true;
         }


### PR DESCRIPTION
## Read power_current asynchronously

Reading /sys/class/power_supply/BAT0/power_now is somewhat expensive: it
requires some ACPI calls and takes several milliseconds (on my laptop
it's around 5). These calls are [cached by the kernel][1] for one
second, so reading several such files is as fast as reading one, but it
still means we're blocking the entire gnome-shell (the compositor is
there!) for a few milliseconds every time we refresh.

See:

    $ time read -r </sys/class/power_supply/BAT0/power_now; \
      time read -r </sys/class/power_supply/BAT0/power_now

    real    0m0,005s
    user    0m0,001s
    sys     0m0,001s

    real    0m0,000s
    user    0m0,000s
    sys     0m0,000s

It's probably not really a big deal, as at 60 Hz each frame takes ~17
ms, and we only block the shell for like 5, but it'd still be nice not
to do this, especially considering that with Wayland, we're not only
blocking the compositor but also inputs like mouse etc.

[1]: https://github.com/torvalds/linux/blob/8830280a69ddfdbba7fb24d79dce309817783c6a/drivers/acpi/battery.c#L62-L64

---

## Support batteries that only report voltage and current, not power

Older ThinkPads used to be like this, and currents Dells (Latitude 7400
for example) does it too.